### PR TITLE
adding first iso processor to be master bionic desktop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: true
+
+language: bash
+
+services:
+  - docker
+
+env:
+  global:
+    - BRANCH="master"
+    - DEBIAN_FRONTEND="noninteractive"
+
+jobs:
+  include:
+    - stage: Build and deploy
+      if: (NOT (type IN (pull_request))) AND (tag IS blank)
+      script:
+        # Determine ISO version
+        - |
+          export ISO_VERSION=$(curl -sL http://releases.ubuntu.com/18.04/MD5SUMS | grep 'desktop' | grep -Po "(\d+\.)+\d+")
+        - sed -i "s/REPLACE_VERSION/${ISO_VERSION}/g" settings.sh
+        # Build the release contents
+        - mkdir -p buildout
+        - cp settings.sh buildout/settings.sh
+        - docker run --rm -it -v $(pwd)/buildout:/buildout netbootxyz/iso-processor
+      before_deploy:
+        # Set up git user name and tag this commit
+        - git config --local user.name $GIT_USERNAME
+        - git config --local user.email $GIT_EMAIL
+        - export TRAVIS_TAG=${ISO_VERSION}-$(echo ${TRAVIS_COMMIT} | cut -c1-8)-${TRAVIS_JOB_NUMBER}
+        - git tag $TRAVIS_TAG
+      deploy:
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: buildout/*
+        skip_cleanup: true
+        on:
+          branch: $BRANCH

--- a/settings.sh
+++ b/settings.sh
@@ -1,0 +1,4 @@
+URL="http://releases.ubuntu.com/18.04/ubuntu-REPLACE_VERSION-desktop-amd64.iso.torrent"
+TYPE=torrent
+CONTENTS="\
+casper/filesystem.squashfs|filesystem.squashfs"


### PR DESCRIPTION
Once we hammer out pushing a release upstream in the form of commit or PR this style will make it so we do not need to basbysit minor versions. 
That logic is not included and also still have not figured out why it is building twice on the tag commit. 