### PR TITLE
Fix for renamed 'filesystem.squashfs' in Ubuntu 23.04

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -3,7 +3,7 @@ TYPE=file
 CONTENTS="\
 casper/vmlinuz|vmlinuz
 casper/initrd|initrd
-casper/filesystem.squashfs|filesystem.squashfs"
+casper/minimal.squashfs|minimal.squashfs"
 EXTRACT_INITRD="true"
 INITRD_NAME="initrd"
 INITRD_TYPE="zstd"

--- a/settings.sh
+++ b/settings.sh
@@ -3,7 +3,7 @@ TYPE=file
 CONTENTS="\
 casper/vmlinuz|vmlinuz
 casper/initrd|initrd
-casper/minimal.squashfs|minimal.squashfs"
+casper/minimal.standard.live.squashfs|minimal.standard.live.squashfs"
 EXTRACT_INITRD="true"
 INITRD_NAME="initrd"
 INITRD_TYPE="zstd"


### PR DESCRIPTION
Fix for  `du: cannot access 'casper/filesystem.squashfs': No such file or directory`

https://github.com/netbootxyz/ubuntu-squash/actions/runs/4899695771/jobs/8749846850#step:6:266