### PR TITLE
Fix pop-20.04 url and implement real version fetching

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1,4 +1,4 @@
-URL="https://pop-iso.sfo2.cdn.digitaloceanspaces.com/20.04/amd64/intel/5/pop-os_20.04_amd64_intel_5.iso"
+URL="https://iso.pop-os.org/20.04/amd64/intel/REPLACE_VERSION/pop-os_20.04_amd64_intel_REPLACE_VERSION.iso"
 TYPE=file
 CONTENTS="\
 casper_pop-os_20.04_*/filesystem.squashfs|filesystem.squashfs

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-VERSION="5"
+VERSION=$(curl https://api.pop-os.org/builds/20.04/intel 2> /dev/null | jq -r .build)
 echo "${VERSION}"


### PR DESCRIPTION
Pop-20.04 CI is failing: https://github.com/netbootxyz/ubuntu-squash/actions/runs/8182721798/job/22374499764
This update the url along with providing a mechanism to get the version of to use using [pop-os api](https://api.pop-os.org/builds/20.04/intel).
If this ok for you, this could applied to `pop-20.04-nvidia` and `pop-22.04`. I could also take the time to create `pop-22.04-nvidia`