### PR TITLE
Add ARM64 HWE kernel variant for Ubuntu 24.04

### DIFF
--- a/.github/workflows/ubuntu-netboot-hwe-24.04-arm64.yml
+++ b/.github/workflows/ubuntu-netboot-hwe-24.04-arm64.yml
@@ -1,9 +1,9 @@
-name: ubuntu-netboot-24.04-arm64
+name: ubuntu-netboot-hwe-24.04-arm64
 
 on:
   push:
     branches:
-      - ubuntu-netboot-24.04-arm64
+      - ubuntu-netboot-hwe-24.04-arm64
     paths-ignore:
       - '.github/workflows/**'
   schedule:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  BRANCH: ubuntu-netboot-24.04-arm64
+  BRANCH: ubuntu-netboot-hwe-24.04-arm64
   GITHUB_ENDPOINT: netbootxyz/ubuntu-squash
   DISCORD_HOOK_URL: ${{ secrets.DISCORD_HOOK_URL }}
   BUILD_TYPE: iso_extraction
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ubuntu-netboot-24.04-arm64
+        ref: ubuntu-netboot-hwe-24.04-arm64
 
     - name: Get SHA of actual branch instead of master
       run: |

--- a/endpoints.template
+++ b/endpoints.template
@@ -1,5 +1,5 @@
 endpoints:
-  ubuntu-netboot-24.04-arm64:
+  ubuntu-netboot-hwe-24.04-arm64:
     path: /ubuntu-squash/releases/download/REPLACE_RELEASE_NAME/
     files:
     - initrd
@@ -7,6 +7,6 @@ endpoints:
     os: ubuntu
     version: 'REPLACE_VERSION'
     codename: noble
-    flavor: netboot
-    kernel: ubuntu-netboot-24.04-arm64
+    flavor: netboot-hwe
+    kernel: ubuntu-netboot-hwe-24.04-arm64
     arch: arm64

--- a/settings.sh
+++ b/settings.sh
@@ -1,8 +1,8 @@
 URL="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-REPLACE_VERSION-live-server-arm64.iso"
 TYPE=file
 CONTENTS="\
-casper/vmlinuz|vmlinuz
-casper/initrd|initrd"
+casper/hwe-vmlinuz|vmlinuz
+casper/hwe-initrd|initrd"
 EXTRACT_INITRD="false"
 INITRD_NAME="initrd"
 INITRD_TYPE="lz4"


### PR DESCRIPTION
The Ubuntu 24.04 ARM64 live server ISO includes both generic and HWE (Hardware Enablement) kernel/initrd in casper/. This adds a new branch that extracts the HWE variants (casper/hwe-vmlinuz, casper/hwe-initrd) instead of the generic ones.

The HWE kernel is required for newer ARM64 hardware (e.g., NVIDIA Grace/ GB200), where the base kernel lacks NIC and DPU driver support needed during network boot and OS installation.

Please create a new branch ubuntu-netboot-hwe-24.04-arm64 from this PR's source branch.